### PR TITLE
remove dependency on boost libraries in plplot test

### DIFF
--- a/toolboxes/plplot/ut/CMakeLists.txt
+++ b/toolboxes/plplot/ut/CMakeLists.txt
@@ -12,7 +12,6 @@ include_directories( ${GTEST_INCLUDE_DIRS}
 include_directories(${GADGETRON_INCLUDE_DIR})
 
 link_libraries( ${GTEST_LIBRARIES} 
-                ${Boost_LIBRARIES} 
                 ${ISMRMRD_LIBRARIES} 
                 ${ARMADILLO_LIBRARIES} 
                 gadgetron_toolbox_plplot 

--- a/toolboxes/plplot/ut/plplot_test.cpp
+++ b/toolboxes/plplot/ut/plplot_test.cpp
@@ -14,8 +14,6 @@
 
 #include "GadgetronTimer.h"
 
-#include <boost/thread/mutex.hpp>
-
 #include "GtPLplot.h"
 
 #ifdef max


### PR DESCRIPTION
This avoids linking problems with boostPython on some systems.
